### PR TITLE
Simplify enchanted book printing recipes in JEI

### DIFF
--- a/src/main/java/plus/dragons/createenchantmentindustry/integration/jei/category/printing/EnchantedBookPrintingRecipeJEI.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/integration/jei/category/printing/EnchantedBookPrintingRecipeJEI.java
@@ -18,19 +18,18 @@
 
 package plus.dragons.createenchantmentindustry.integration.jei.category.printing;
 
-import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
+import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
 import mezz.jei.api.helpers.ICodecHelper;
+import mezz.jei.api.neoforge.NeoForgeTypes;
+import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.IRecipeManager;
+import mezz.jei.api.recipe.RecipeIngredientRole;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -38,7 +37,9 @@ import net.minecraft.world.item.EnchantedBookItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.EnchantmentInstance;
+import net.neoforged.neoforge.fluids.FluidStack;
 import plus.dragons.createdragonsplus.util.Pairs;
 import plus.dragons.createenchantmentindustry.common.CEICommon;
 import plus.dragons.createenchantmentindustry.common.processing.enchanter.CEIEnchantmentHelper;
@@ -48,29 +49,28 @@ import plus.dragons.createenchantmentindustry.common.registry.CEIFluids;
 import plus.dragons.createenchantmentindustry.config.CEIConfig;
 import plus.dragons.createenchantmentindustry.util.CEIIntIntPair;
 
+import java.util.List;
+import java.util.Optional;
+
 public class EnchantedBookPrintingRecipeJEI implements PrintingRecipeJEI {
     public static final PrintingRecipeJEI.Type TYPE = PrintingRecipeJEI
             .register(CEICommon.asResource("enchanted_book"), EnchantedBookPrintingRecipeJEI::createCodec);
     private final ResourceLocation id;
     private final ResourceKey<Enchantment> enchantmentKey;
-    private final int level;
 
-    public EnchantedBookPrintingRecipeJEI(ResourceKey<Enchantment> enchantmentKey, int level) {
+    public EnchantedBookPrintingRecipeJEI(ResourceKey<Enchantment> enchantmentKey) {
         this.id = PrintingRecipeJEI.super.getRegistryName().withSuffix("/" +
                 enchantmentKey.location().getNamespace() + "/" +
-                enchantmentKey.location().getPath() + "/" +
-                level);
+                enchantmentKey.location().getPath());
         this.enchantmentKey = enchantmentKey;
-        this.level = level;
     }
 
     public static MapCodec<EnchantedBookPrintingRecipeJEI> createCodec(ICodecHelper codecHelper, IRecipeManager recipeManager) {
         return RecordCodecBuilder.mapCodec(instance -> instance.group(
-                ResourceLocation.CODEC.fieldOf("enchantment")
-                        .forGetter((EnchantedBookPrintingRecipeJEI recipe) -> recipe.enchantmentKey.location()),
-                Codec.INT.fieldOf("level")
-                        .forGetter(recipe -> recipe.level))
-                .apply(instance, (enchantment, level) -> new EnchantedBookPrintingRecipeJEI(ResourceKey.create(Registries.ENCHANTMENT, enchantment), level)));
+                        ResourceLocation.CODEC.fieldOf("enchantment")
+                                .forGetter((EnchantedBookPrintingRecipeJEI recipe) -> recipe.enchantmentKey.location()))
+                .apply(instance, enchantment ->
+                        new EnchantedBookPrintingRecipeJEI(ResourceKey.create(Registries.ENCHANTMENT, enchantment))));
     }
 
     public static List<PrintingRecipeJEI> listAll() {
@@ -81,11 +81,9 @@ public class EnchantedBookPrintingRecipeJEI implements PrintingRecipeJEI {
                 .lookupOrThrow(Registries.ENCHANTMENT)
                 .listElements()
                 .filter(enchantment -> !enchantment.is(CEIEnchantments.MOD_TAGS.printingDeny))
-                .flatMap(enchantment -> enchantment.unwrapKey().stream()
-                        .flatMap(key -> IntStream
-                                .rangeClosed(enchantment.value().getMinLevel(), CEIEnchantmentHelper.maxLevel(enchantment))
-                                .mapToObj(level -> new EnchantedBookPrintingRecipeJEI(key, level))))
-                .collect(Collectors.toList());
+                .flatMap(enchantment -> enchantment.unwrapKey().stream())
+                .map(key -> (PrintingRecipeJEI) new EnchantedBookPrintingRecipeJEI(key))
+                .toList();
     }
 
     private Optional<Holder.Reference<Enchantment>> resolveEnchantment() {
@@ -97,23 +95,26 @@ public class EnchantedBookPrintingRecipeJEI implements PrintingRecipeJEI {
                 .get(enchantmentKey);
     }
 
-    private Optional<ItemStack> createEnchantmentBook() {
-        return resolveEnchantment()
-                .map(enchantment -> EnchantedBookItem.createForEnchantment(new EnchantmentInstance(enchantment, level)));
+    private static ItemStack createEnchantmentBook(Holder.Reference<Enchantment> enchantment, int level) {
+        return EnchantedBookItem.createForEnchantment(new EnchantmentInstance(enchantment, level));
     }
 
-    private OptionalInt getCost() {
-        return resolveEnchantment()
-                .map(enchantment -> {
-                    Optional<CEIIntIntPair> optional = Optional.empty();
-                    var customCost = enchantment.getData(CEIDataMaps.PRINTING_ENCHANTED_BOOK_COST);
-                    if (customCost != null) {
-                        optional = customCost.stream().filter(pair -> pair.level() == level).findFirst();
-                    }
-                    return (int) (optional.map(CEIIntIntPair::value).orElseGet(() -> CEIEnchantmentHelper.getEnchantmentCost(enchantment, level)) * CEIConfig.fluids().printingEnchantedBookCostMultiplier.get());
-                })
-                .map(OptionalInt::of)
-                .orElseGet(OptionalInt::empty);
+    private int getCost(Holder.Reference<Enchantment> enchantment, int level) {
+        Optional<CEIIntIntPair> optional = Optional.empty();
+        var customCost = enchantment.getData(CEIDataMaps.PRINTING_ENCHANTED_BOOK_COST);
+        if (customCost != null) optional = customCost.stream().filter(pair -> pair.level() == level).findFirst();
+        return optional
+                .map(CEIIntIntPair::value)
+                .orElseGet(() -> (int) (CEIEnchantmentHelper.getEnchantmentCost(enchantment, level)
+                        * CEIConfig.fluids().printingEnchantedBookCostMultiplier.get()));
+    }
+
+    private void addAllLevels(IRecipeSlotBuilder slot) {
+        resolveEnchantment().ifPresent(enchantment -> {
+            for (int level = enchantment.value().getMinLevel(); level <= CEIEnchantmentHelper.maxLevel(enchantment); level++) {
+                slot.addItemStack(createEnchantmentBook(enchantment, level));
+            }
+        });
     }
 
     @Override
@@ -123,21 +124,27 @@ public class EnchantedBookPrintingRecipeJEI implements PrintingRecipeJEI {
 
     @Override
     public void setTemplate(IRecipeSlotBuilder slot) {
-        createEnchantmentBook().ifPresent(slot::addItemStack);
+        addAllLevels(slot);
     }
 
     @Override
     public void setFluid(IRecipeSlotBuilder slot) {
-        getCost().ifPresent(cost -> {
-            slot.addFluidStack(CEIFluids.EXPERIENCE.get(), cost);
-            CEIDataMaps.getSourceFluidEntries(CEIDataMaps.FLUID_UNIT_EXPERIENCE)
-                    .forEach(Pairs.accept((fluid, unit) -> slot.addFluidStack(fluid, (long) unit * cost)));
+        resolveEnchantment().ifPresent(enchantment -> {
+            for (int level = enchantment.value().getMinLevel(); level <= CEIEnchantmentHelper.maxLevel(enchantment); level++) {
+                int cost = getCost(enchantment, level);
+                if (cost <= 0)
+                    continue;
+
+                slot.addFluidStack(CEIFluids.EXPERIENCE.get(), cost);
+                CEIDataMaps.getSourceFluidEntries(CEIDataMaps.FLUID_UNIT_EXPERIENCE)
+                        .forEach(Pairs.accept((fluid, unit) -> slot.addFluidStack(fluid, (long) unit * cost)));
+            }
         });
     }
 
     @Override
     public void setOutput(IRecipeSlotBuilder slot) {
-        createEnchantmentBook().ifPresent(slot::addItemStack);
+        addAllLevels(slot);
     }
 
     @Override
@@ -148,5 +155,40 @@ public class EnchantedBookPrintingRecipeJEI implements PrintingRecipeJEI {
     @Override
     public ResourceLocation getRegistryName() {
         return id;
+    }
+
+    @Override
+    public void onDisplayedIngredientsUpdate(IRecipeSlotDrawable baseSlot, IRecipeSlotDrawable templateSlot,
+                                             IRecipeSlotDrawable fluidSlot, IRecipeSlotDrawable outputSlot,
+                                             IFocusGroup focuses) {
+        resolveEnchantment().ifPresent(enchantment -> {
+            boolean hasOutputFocus = focuses.getFocuses(RecipeIngredientRole.OUTPUT).findAny().isPresent();
+            ItemStack displayed = (hasOutputFocus ? outputSlot : templateSlot)
+                    .getDisplayedItemStack()
+                    .orElse(ItemStack.EMPTY);
+
+            int level = EnchantmentHelper.getEnchantmentsForCrafting(displayed).getLevel(enchantment);
+            if (level <= 0)
+                level = enchantment.value().getMinLevel();
+
+            var stack = createEnchantmentBook(enchantment, level);
+            if (hasOutputFocus)
+                templateSlot.createDisplayOverrides().addItemStack(stack);
+            else
+                outputSlot.createDisplayOverrides().addItemStack(stack);
+
+            int cost = getCost(enchantment, level);
+            if (cost <= 0) return;
+            var displayedFluid = fluidSlot.getDisplayedIngredient(NeoForgeTypes.FLUID_STACK).orElse(FluidStack.EMPTY);
+            var fluid = displayedFluid.isEmpty() ? CEIFluids.EXPERIENCE.get() : displayedFluid.getFluid();
+            if (fluid != CEIFluids.EXPERIENCE.get()) {
+                var unit = BuiltInRegistries.FLUID.wrapAsHolder(fluid).getData(CEIDataMaps.FLUID_UNIT_EXPERIENCE);
+                if (unit != null) {
+                    fluidSlot.createDisplayOverrides().addIngredient(NeoForgeTypes.FLUID_STACK, new FluidStack(fluid, Math.toIntExact((long) unit * cost)));
+                    return;
+                }
+            }
+            fluidSlot.createDisplayOverrides().addIngredient(NeoForgeTypes.FLUID_STACK, new FluidStack(CEIFluids.EXPERIENCE.get(), cost));
+        });
     }
 }

--- a/src/main/java/plus/dragons/createenchantmentindustry/integration/jei/category/printing/EnchantedBookPrintingRecipeJEI.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/integration/jei/category/printing/EnchantedBookPrintingRecipeJEI.java
@@ -29,7 +29,6 @@ import mezz.jei.api.recipe.IRecipeManager;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Holder;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -42,12 +41,12 @@ import net.minecraft.world.item.enchantment.EnchantmentInstance;
 import net.neoforged.neoforge.fluids.FluidStack;
 import plus.dragons.createdragonsplus.util.Pairs;
 import plus.dragons.createenchantmentindustry.common.CEICommon;
+import plus.dragons.createenchantmentindustry.common.fluids.experience.ExperienceHelper;
 import plus.dragons.createenchantmentindustry.common.processing.enchanter.CEIEnchantmentHelper;
 import plus.dragons.createenchantmentindustry.common.registry.CEIDataMaps;
 import plus.dragons.createenchantmentindustry.common.registry.CEIEnchantments;
 import plus.dragons.createenchantmentindustry.common.registry.CEIFluids;
 import plus.dragons.createenchantmentindustry.config.CEIConfig;
-import plus.dragons.createenchantmentindustry.util.CEIIntIntPair;
 
 import java.util.List;
 import java.util.Optional;
@@ -100,13 +99,15 @@ public class EnchantedBookPrintingRecipeJEI implements PrintingRecipeJEI {
     }
 
     private int getCost(Holder.Reference<Enchantment> enchantment, int level) {
-        Optional<CEIIntIntPair> optional = Optional.empty();
         var customCost = enchantment.getData(CEIDataMaps.PRINTING_ENCHANTED_BOOK_COST);
-        if (customCost != null) optional = customCost.stream().filter(pair -> pair.level() == level).findFirst();
-        return optional
-                .map(CEIIntIntPair::value)
-                .orElseGet(() -> (int) (CEIEnchantmentHelper.getEnchantmentCost(enchantment, level)
-                        * CEIConfig.fluids().printingEnchantedBookCostMultiplier.get()));
+        if (customCost != null) {
+            for (var pair : customCost) {
+                if (pair.level() == level)
+                    return pair.value();
+            }
+        }
+        return (int) (CEIEnchantmentHelper.getEnchantmentCost(enchantment, level)
+                * CEIConfig.fluids().printingEnchantedBookCostMultiplier.get());
     }
 
     private void addAllLevels(IRecipeSlotBuilder slot) {
@@ -132,9 +133,6 @@ public class EnchantedBookPrintingRecipeJEI implements PrintingRecipeJEI {
         resolveEnchantment().ifPresent(enchantment -> {
             for (int level = enchantment.value().getMinLevel(); level <= CEIEnchantmentHelper.maxLevel(enchantment); level++) {
                 int cost = getCost(enchantment, level);
-                if (cost <= 0)
-                    continue;
-
                 slot.addFluidStack(CEIFluids.EXPERIENCE.get(), cost);
                 CEIDataMaps.getSourceFluidEntries(CEIDataMaps.FLUID_UNIT_EXPERIENCE)
                         .forEach(Pairs.accept((fluid, unit) -> slot.addFluidStack(fluid, (long) unit * cost)));
@@ -158,37 +156,24 @@ public class EnchantedBookPrintingRecipeJEI implements PrintingRecipeJEI {
     }
 
     @Override
-    public void onDisplayedIngredientsUpdate(IRecipeSlotDrawable baseSlot, IRecipeSlotDrawable templateSlot,
-                                             IRecipeSlotDrawable fluidSlot, IRecipeSlotDrawable outputSlot,
-                                             IFocusGroup focuses) {
+    public void onDisplayedIngredientsUpdate(IRecipeSlotDrawable baseSlot, IRecipeSlotDrawable templateSlot, IRecipeSlotDrawable fluidSlot, IRecipeSlotDrawable outputSlot, IFocusGroup focuses) {
         resolveEnchantment().ifPresent(enchantment -> {
             boolean hasOutputFocus = focuses.getFocuses(RecipeIngredientRole.OUTPUT).findAny().isPresent();
-            ItemStack displayed = (hasOutputFocus ? outputSlot : templateSlot)
-                    .getDisplayedItemStack()
-                    .orElse(ItemStack.EMPTY);
+            ItemStack displayed = (hasOutputFocus ? outputSlot : templateSlot).getDisplayedItemStack().orElse(ItemStack.EMPTY);
 
             int level = EnchantmentHelper.getEnchantmentsForCrafting(displayed).getLevel(enchantment);
-            if (level <= 0)
-                level = enchantment.value().getMinLevel();
+            if (level <= 0) level = enchantment.value().getMinLevel();
 
             var stack = createEnchantmentBook(enchantment, level);
-            if (hasOutputFocus)
-                templateSlot.createDisplayOverrides().addItemStack(stack);
-            else
-                outputSlot.createDisplayOverrides().addItemStack(stack);
+            if (hasOutputFocus) templateSlot.createDisplayOverrides().addItemStack(stack);
+            else outputSlot.createDisplayOverrides().addItemStack(stack);
 
             int cost = getCost(enchantment, level);
-            if (cost <= 0) return;
-            var displayedFluid = fluidSlot.getDisplayedIngredient(NeoForgeTypes.FLUID_STACK).orElse(FluidStack.EMPTY);
-            var fluid = displayedFluid.isEmpty() ? CEIFluids.EXPERIENCE.get() : displayedFluid.getFluid();
-            if (fluid != CEIFluids.EXPERIENCE.get()) {
-                var unit = BuiltInRegistries.FLUID.wrapAsHolder(fluid).getData(CEIDataMaps.FLUID_UNIT_EXPERIENCE);
-                if (unit != null) {
-                    fluidSlot.createDisplayOverrides().addIngredient(NeoForgeTypes.FLUID_STACK, new FluidStack(fluid, Math.toIntExact((long) unit * cost)));
-                    return;
-                }
-            }
-            fluidSlot.createDisplayOverrides().addIngredient(NeoForgeTypes.FLUID_STACK, new FluidStack(CEIFluids.EXPERIENCE.get(), cost));
+            var displayedFluid = fluidSlot.getDisplayedIngredient(NeoForgeTypes.FLUID_STACK)
+                    .orElse(new FluidStack(CEIFluids.EXPERIENCE.get(), cost));
+
+            fluidSlot.createDisplayOverrides().addIngredient(NeoForgeTypes.FLUID_STACK,
+                    displayedFluid.copyWithAmount(ExperienceHelper.getFluidFromExperience(displayedFluid, cost)));
         });
     }
 }


### PR DESCRIPTION
## Summary

Each level of each enchantment was shown as a separate recipe, which made the printer recipe page very large. I think this can probably be simplified a bit, so I submit this pr.

<img width="603" height="418" alt="image" src="https://github.com/user-attachments/assets/828e6bd9-4a51-4f66-b038-3eac4468bf2f" />


- Show all printable levels of each enchantment in a single JEI enchanted book printing recipe.
- Synchronize the displayed template, output, and fluid amount when JEI cycles between enchanted book levels.

## Details

This changes enchanted book printing JEI entries from level-specific recipe instances to one recipe per enchantment. The recipe slots include all supported levels, and `onDisplayedIngredientsUpdate` keeps the paired book slot and fluid amount aligned with the currently displayed level.

The codec no longer stores `level`, since level is now represented by the displayed ingredient state.